### PR TITLE
Fix style.css

### DIFF
--- a/share/style.css
+++ b/share/style.css
@@ -1,1 +1,1 @@
-GtkTextView { font-family: sans; font-size: 10px; }
+textview { font-family: sans; font-size: 10px; }


### PR DESCRIPTION
Change the selector `GtkTextView` to `textview`. Now the user can edit `/usr/local/share/ferret/style.css` and modify the font style that the program displays.

Fixes #9 .

These are the references that got me to the right answer: https://docs.gtk.org/gtk3/class.TextView.html and https://stackoverflow.com/questions/41276368/need-to-make-transparent-textview-on-gtk